### PR TITLE
add keys inside config if not already present

### DIFF
--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -50,6 +50,10 @@ function pub.apply_to_config(config, opts)
         end
     end
 
+    if config.keys == nil then
+      config.keys = {}
+    end
+
     table.insert(config.keys, {
         key = key,
         mods = mods,


### PR DESCRIPTION
Added a condition to check if 'keys' exist inside config, if not then it's created before trying to insert it